### PR TITLE
chore: rename Next.js config to mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,3 @@
+const nextConfig = {};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,0 @@
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  experimental: {
-    serverActions: true,
-  },
-}
-
-export default nextConfig


### PR DESCRIPTION
## Summary
- rename TypeScript config to `next.config.mjs`
- simplify config with default export

## Testing
- `npm test`
- `npm run dev` *(fails: requires @types/react, @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d3d6b4748320a7eab30d920eab77